### PR TITLE
add the name of the peers to the list returned by get_peers

### DIFF
--- a/py2/asyncoro/disasyncoro.py
+++ b/py2/asyncoro/disasyncoro.py
@@ -110,7 +110,7 @@ class _Peer(object):
     @staticmethod
     def get_peers():
         _Peer._lock.acquire()
-        peers = [Location(addr, port) for (addr, port) in _Peer.peers.iterkeys()]
+        peers = [PeerStatus(peer.location, peer.name, PeerStatus.Online) for peer in _Peer.peers.itervalues()]
         _Peer._lock.release()
         return peers
 

--- a/py3/asyncoro/disasyncoro.py
+++ b/py3/asyncoro/disasyncoro.py
@@ -110,7 +110,7 @@ class _Peer(object):
     @staticmethod
     def get_peers():
         _Peer._lock.acquire()
-        peers = [Location(addr, port) for (addr, port) in _Peer.peers.keys()]
+        peers = [PeerStatus(peer.location, peer.name, PeerStatus.Online) for peer in _Peer.peers.itervalues()]
         _Peer._lock.release()
         return peers
 


### PR DESCRIPTION
It's nice to have the name of the peers connected besides the location.